### PR TITLE
Solve admin pod issue link to null value

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ helm install mytock ./charts/tock
 ## DLDR
 
 ```console
-$ helm install my-release oci://registry.hub.docker.com/onelans/tock --version 0.4.5
+$ helm install my-release oci://registry.hub.docker.com/onelans/tock --version 0.4.6
 ```
 
 You will find more information on chart parameters at the helm chart [README](charts/tock/README.md).

--- a/charts/tock/Chart.yaml
+++ b/charts/tock/Chart.yaml
@@ -5,7 +5,7 @@ name: tock
 icon: https://doc.tock.ai/tock/assets/images/logo-white.svg
 home: https://doc.tock.ai
 type: application
-version: 0.4.5
+version: 0.4.6
 sources: 
 - https://github.com/theopenconversationkit/tock-helm-chart
 - https://github.com/theopenconversationkit

--- a/charts/tock/README.md
+++ b/charts/tock/README.md
@@ -44,11 +44,11 @@ This creates values, but sectioned into own section tables if a section comment 
 | adminWeb.containerSecurityContext.runAsUser | int | `99` | Run as user id |
 | adminWeb.environment.botadminverticle_base_href | string | `""` | Have to be set if tock studio is deployed as subdomain https://sssss/tockstudio |
 | adminWeb.environment.botadminverticle_body_limit | string | `"-1"` | botadminverticle_body_limit |
-| adminWeb.environment.tock_database_mongodb_secret_manager_provider | string | `"null"` | Environment variable settings for secrets (when used). Allowed values Env,AwsSecretsManager,GcpSecretManager. The provider of the secret manager used to retrieve credentials for database access (mongodb). |
+| adminWeb.environment.tock_database_mongodb_secret_manager_provider | string | `nil` | Environment variable settings for secrets (when used). Allowed values Env,AwsSecretsManager,GcpSecretManager. The provider of the secret manager used to retrieve credentials for database access (mongodb). |
 | adminWeb.environment.tock_default_log_level | string | `"info"` | log level |
 | adminWeb.environment.tock_env | string | `"false"` | tock_env |
-| adminWeb.environment.tock_gcp_project_id | string | `"null"` | Environment variable settings for secrets (when used). The GCP project ID used to retrieve credentials for GCP Secret Manager. |
-| adminWeb.environment.tock_gcp_region | string | `"null"` | Environment variable settings for secrets (when used).The GCP project Region where secrets are stored. |
+| adminWeb.environment.tock_gcp_project_id | string | `nil` | Environment variable settings for secrets (when used). The GCP project ID used to retrieve credentials for GCP Secret Manager. |
+| adminWeb.environment.tock_gcp_region | string | `nil` | Environment variable settings for secrets (when used).The GCP project Region where secrets are stored. |
 | adminWeb.environment.tock_gen_ai_secret_prefix | string | `"LOCAL/TOCK"` | Environment variable settings for secrets (when used).The prefix to use to store the Gen AI Api Keys in the database.Allowed values PROD,DEV,LOCAL,FEAT-. The prefix is used to identify the environment in which the keys are stored. |
 | adminWeb.environment.tock_https_env | string | `"prod"` | Environment |
 | adminWeb.image.pullSecrets | list | `[]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ e.g: pullSecrets:   - myRegistryKeySecretName |
@@ -83,12 +83,12 @@ This creates values, but sectioned into own section tables if a section comment 
 | botApi.environment.tock_api_timout_in_s | string | `"10"` | Timeout in seconds for websocket service, default is 10 |
 | botApi.environment.tock_bot_api_actions_history_to_client_bus | string | `"false"` | Set to true if you want to transfer action history in UserRequest context (payload is larger), default is false |
 | botApi.environment.tock_bot_api_timeout_in_ms | string | `"5000"` | Timeout in milliseconds for webhook service, default is 5000 |
-| botApi.environment.tock_database_mongodb_secret_manager_provider | string | `"null"` | Environment variable settings for secrets (when used). Allowed values Env,AwsSecretsManager,GcpSecretManager. The provider of the secret manager used to retrieve credentials for database access (mongodb). |
+| botApi.environment.tock_database_mongodb_secret_manager_provider | string | `nil` | Environment variable settings for secrets (when used). Allowed values Env,AwsSecretsManager,GcpSecretManager. The provider of the secret manager used to retrieve credentials for database access (mongodb). |
 | botApi.environment.tock_default_log_level | string | `"info"` | bot api log level |
 | botApi.environment.tock_env | string | `"integ"` | tock environment (prod, dev, integ) |
-| botApi.environment.tock_gcp_project_id | string | `"null"` | Environment variable settings for secrets (when used). The GCP project ID used to retrieve credentials for GCP Secret Manager. |
-| botApi.environment.tock_iadvize_credentials_secret_name | string | `"null"` | Environment variable settings for secrets (when used).(When using iAdvize Connector) The secret name storing iAdvize credentials. |
-| botApi.environment.tock_iadvize_secret_manager_provider | string | `"null"` | Environment variable settings for secrets (when used).(When using iAdvize Connector) The provider of the secret manager used to retrieve credentials for iAdvize (GraphQL)  |
+| botApi.environment.tock_gcp_project_id | string | `nil` | Environment variable settings for secrets (when used). The GCP project ID used to retrieve credentials for GCP Secret Manager. |
+| botApi.environment.tock_iadvize_credentials_secret_name | string | `nil` | Environment variable settings for secrets (when used).(When using iAdvize Connector) The secret name storing iAdvize credentials. |
+| botApi.environment.tock_iadvize_secret_manager_provider | string | `nil` | Environment variable settings for secrets (when used).(When using iAdvize Connector) The provider of the secret manager used to retrieve credentials for iAdvize (GraphQL)  |
 | botApi.environment.tock_web_connector_extra_headers | string | `""` | List of extra headers to retrieve metadata from and use them in `Bus` in the `ConnectorData`. The list should be separated by `,`. Sample `tock_web_connector_extra_headers=header1,header2,my-other-header-param`. |
 | botApi.environment.tock_web_connector_use_extra_header_as_metadata_request | string | `"false"` | To retrieve metadata present in extra headers (the list present in `tock_web_connector_extra_headers`) and use them in `Bus` in the `ConnectorData`, use the `tock_web_connector_use_extra_header_as_metadata_request` and pass it to true. |
 | botApi.environment.tock_web_enable_markdown | string | `"false"` | Enable markdown |
@@ -172,18 +172,18 @@ This creates values, but sectioned into own section tables if a section comment 
 | genAiOrchestrator.containerSecurityContext.runAsGroup | int | `99` | Run as Group id |
 | genAiOrchestrator.containerSecurityContext.runAsNonRoot | bool | `true` | Run as non root |
 | genAiOrchestrator.containerSecurityContext.runAsUser | int | `99` | Run as user id |
-| genAiOrchestrator.environment.tock_gcp_project_id | string | `"null"` | Environment variable settings for secrets (when used). The GCP project ID used to retrieve credentials for GCP Secret Manager. |
+| genAiOrchestrator.environment.tock_gcp_project_id | string | `nil` | Environment variable settings for secrets (when used). The GCP project ID used to retrieve credentials for GCP Secret Manager. |
 | genAiOrchestrator.environment.tock_gen_ai_orchestrator_application_environment | string | `"DEV"` | DEV or PROD in uppercase only |
 | genAiOrchestrator.environment.tock_gen_ai_orchestrator_em_provider_timeout | int | `120` | llm embedding retries |
 | genAiOrchestrator.environment.tock_gen_ai_orchestrator_llm_provider_max_retries | int | `0` | llm retries |
 | genAiOrchestrator.environment.tock_gen_ai_orchestrator_llm_provider_timeout | int | `120` | llm timeout |
-| genAiOrchestrator.environment.tock_gen_ai_orchestrator_vector_store_credentials_secret_name | string | `""` | Vector Store secret manager secret name |
+| genAiOrchestrator.environment.tock_gen_ai_orchestrator_vector_store_credentials_secret_name | string | `nil` | Vector Store secret manager secret name |
 | genAiOrchestrator.environment.tock_gen_ai_orchestrator_vector_store_database | string | `nil` | Vector Store index |
 | genAiOrchestrator.environment.tock_gen_ai_orchestrator_vector_store_k | int | `4` | Vector K |
 | genAiOrchestrator.environment.tock_gen_ai_orchestrator_vector_store_port | int | `9200` | Vector Store port |
 | genAiOrchestrator.environment.tock_gen_ai_orchestrator_vector_store_provider | string | `"OpenSearch"` | Vector Store host, Cloud be OpenSearch or PGVector |
 | genAiOrchestrator.environment.tock_gen_ai_orchestrator_vector_store_pwd | string | `"admin"` | Vector Store password |
-| genAiOrchestrator.environment.tock_gen_ai_orchestrator_vector_store_secret_manager_provider | string | `"AWS_SECRETS_MANAGER"` | Vector Store secret manager provider. Values could be AWS_SECRETS_MANAGER or GCP_SECRET_MANAGER |
+| genAiOrchestrator.environment.tock_gen_ai_orchestrator_vector_store_secret_manager_provider | string | `nil` | Vector Store secret manager provider. Values could be AWS_SECRETS_MANAGER or GCP_SECRET_MANAGER |
 | genAiOrchestrator.environment.tock_gen_ai_orchestrator_vector_store_test_query | string | `"What knowledge do you have?"` | Vector Store test query |
 | genAiOrchestrator.environment.tock_gen_ai_orchestrator_vector_store_timeout | int | `5` | Vector Store timeout |
 | genAiOrchestrator.environment.tock_gen_ai_orchestrator_vector_store_user | string | `"admin"` | Vector Store login |
@@ -275,7 +275,7 @@ This creates values, but sectioned into own section tables if a section comment 
 | nlpApi.containerSecurityContext.runAsGroup | int | `99` | Run as Group id |
 | nlpApi.containerSecurityContext.runAsNonRoot | bool | `true` | Run as non root |
 | nlpApi.containerSecurityContext.runAsUser | int | `99` | Run as user id |
-| nlpApi.environment.tock_database_mongodb_secret_manager_provider | string | `"null"` | Environment variable settings for secrets (when used). Allowed values Env,AwsSecretsManager,GcpSecretManager. The provider of the secret manager used to retrieve credentials for database access (mongodb). |
+| nlpApi.environment.tock_database_mongodb_secret_manager_provider | string | `nil` | Environment variable settings for secrets (when used). Allowed values Env,AwsSecretsManager,GcpSecretManager. The provider of the secret manager used to retrieve credentials for database access (mongodb). |
 | nlpApi.environment.tock_default_log_level | string | `"info"` | tock environment (prod, dev, integ) |
 | nlpApi.environment.tock_env | string | `"prod"` | tock environment (prod, dev, integ) |
 | nlpApi.environment.tock_web_use_default_cors_handler | string | `"true"` | cors handler |
@@ -307,12 +307,12 @@ This creates values, but sectioned into own section tables if a section comment 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| adminWeb.environment.tock_database_mongodb_credentials_secret_name | string | `"null"` | Environment variable settings for secrets (when used). The secret name storing database credentials (Only if credentials are not passed in the MongoBD connection string URI). |
-| adminWeb.environment.tock_gen_ai_secret_manager_provider | string | `"null"` | Environment variable settings for secrets (when used).Allowed values : Env,AwsSecretsManager,GcpSecretManager. The provider of the secret manager used to store and retrieve the Gen AI Api Keys.The secret will be stored directly in the database in text format, so it can only be used for local development purposes, which is obviously not a sure thing. |
-| botApi.environment.tock_database_mongodb_credentials_secret_name | string | `"null"` | Environment variable settings for secrets (when used). The secret name storing database credentials (Only if credentials are not passed in the MongoBD connection string URI). |
+| adminWeb.environment.tock_database_mongodb_credentials_secret_name | string | `nil` | Environment variable settings for secrets (when used). The secret name storing database credentials (Only if credentials are not passed in the MongoBD connection string URI). |
+| adminWeb.environment.tock_gen_ai_secret_manager_provider | string | `nil` | Environment variable settings for secrets (when used).Allowed values : Env,AwsSecretsManager,GcpSecretManager. The provider of the secret manager used to store and retrieve the Gen AI Api Keys.The secret will be stored directly in the database in text format, so it can only be used for local development purposes, which is obviously not a sure thing. |
+| botApi.environment.tock_database_mongodb_credentials_secret_name | string | `nil` | Environment variable settings for secrets (when used). The secret name storing database credentials (Only if credentials are not passed in the MongoBD connection string URI). |
 | genAiOrchestrator.environment.tock_gen_ai_orchestrator_vector_store_host | string | `"opensearch-node1"` |  |
 | global.deployOpenSearch.useExisting | bool | `false` | If true use an existing OpenSearch cluster |
-| nlpApi.environment.tock_database_mongodb_credentials_secret_name | string | `"null"` | Environment variable settings for secrets (when used). The secret name storing database credentials (Only if credentials are not passed in the MongoBD connection string URI). |
+| nlpApi.environment.tock_database_mongodb_credentials_secret_name | string | `nil` | Environment variable settings for secrets (when used). The secret name storing database credentials (Only if credentials are not passed in the MongoBD connection string URI). |
 | opensearch.extraEnvs[0].name | string | `"OPENSEARCH_INITIAL_ADMIN_PASSWORD"` |  |
 | opensearch.extraEnvs[0].value | string | `"DoThisOne12+"` |  |
 

--- a/charts/tock/README.md
+++ b/charts/tock/README.md
@@ -2,7 +2,7 @@
 
 A helm chart for Tock. Tock is an open conversational AI platform. It's a complete solution to build conversational agents aka bots.Tock can integrate and experiment with both classic and Generative AI (LLM, RAG) models
 
-![Version: 0.4.5](https://img.shields.io/badge/Version-0.4.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 24.9.6](https://img.shields.io/badge/AppVersion-24.9.6-informational?style=flat-square)
+![Version: 0.4.6](https://img.shields.io/badge/Version-0.4.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 24.9.6](https://img.shields.io/badge/AppVersion-24.9.6-informational?style=flat-square)
 
 ## DLDR
 
@@ -10,7 +10,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 $ helm registry login -u myuser registry.hub.docker.com
-$ helm install my-release  oci://registry.hub.docker.com/onelans/tock --version 0.4.5
+$ helm install my-release  oci://registry.hub.docker.com/onelans/tock --version 0.4.6
 ```
 
 ## Introduction

--- a/charts/tock/README.md.gotmpl
+++ b/charts/tock/README.md.gotmpl
@@ -11,7 +11,7 @@ To install the chart with the release name `my-release`:
 
 ```console
 $ helm registry login -u myuser registry.hub.docker.com 
-$ helm install my-release  oci://registry.hub.docker.com/onelans/{{ template "chart.name" . }} --version 0.4.5
+$ helm install my-release  oci://registry.hub.docker.com/onelans/{{ template "chart.name" . }} --version 0.4.6
 ```
 
 ## Introduction

--- a/charts/tock/templates/admin_web.configmap.yaml
+++ b/charts/tock/templates/admin_web.configmap.yaml
@@ -59,13 +59,9 @@ data:
     tock_gen_ai_orchestrator_vector_store_provider: '{{ default "OpenSearch" .Values.adminWeb.environment.tock_gen_ai_orchestrator_vector_store_provider }}'
 {{- if .Values.adminWeb.environment.tock_database_mongodb_secret_manager_provider }}
     tock_database_mongodb_secret_manager_provider: '{{ .Values.adminWeb.environment.tock_database_mongodb_secret_manager_provider }}'
-{{- else }}
-    tock_database_mongodb_secret_manager_provider: null
 {{- end }}
 {{- if .Values.adminWeb.environment.tock_database_mongodb_credentials_secret_name }}
     tock_database_mongodb_credentials_secret_name: '{{ .Values.adminWeb.environment.tock_database_mongodb_credentials_secret_name }}'
-{{- else }}
-    tock_database_mongodb_credentials_secret_name: null
 {{- end }}
 {{- if .Values.adminWeb.environment.tock_gen_ai_secret_manager_provider }}
     tock_gen_ai_secret_manager_provider: '{{ .Values.adminWeb.environment.tock_gen_ai_secret_manager_provider }}'

--- a/charts/tock/templates/admin_web.configmap.yaml
+++ b/charts/tock/templates/admin_web.configmap.yaml
@@ -65,17 +65,11 @@ data:
 {{- end }}
 {{- if .Values.adminWeb.environment.tock_gen_ai_secret_manager_provider }}
     tock_gen_ai_secret_manager_provider: '{{ .Values.adminWeb.environment.tock_gen_ai_secret_manager_provider }}'
-{{- else }}
-    tock_gen_ai_secret_manager_provider: null
 {{- end }}  
     tock_gen_ai_secret_prefix: '{{ default "LOCAL/TOCK" .Values.adminWeb.environment.tock_gen_ai_secret_prefix }}'
 {{- if  .Values.adminWeb.environment.tock_gcp_project_id }}
     tock_gcp_project_id: '{{ .Values.adminWeb.environment.tock_gcp_project_id }}'
-{{- else }}
-    tock_gcp_project_id: null
 {{- end }}  
 {{- if  .Values.adminWeb.environment.tock_gcp_region }}
     tock_gcp_region: '{{ .Values.adminWeb.environment.tock_gcp_region }}'
-{{- else }} 
-    tock_gcp_region: null
 {{- end }}


### PR DESCRIPTION
Null values in templates are not well supported. 
It PR solve it issues for admin pod. 
Chart version was upgraded to 0.4.6 version. 
