### PR TITLE
chore(helm): bump chart version to 0.6.3 and improve truststore handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The chart is distributed as an OCI Artifact as well as via a traditional Helm Re
 ## Install Chart
 
 ```console
-$ helm install [RELEASE_NAME] oci://ghcr.io/theopenconversationkit/charts/tock --version 0.6.2
+$ helm install [RELEASE_NAME] oci://ghcr.io/theopenconversationkit/charts/tock --version 0.6.3
 ```
 
 or
@@ -31,7 +31,7 @@ or
 helm repo add tock https://theopenconversationkit.github.io/tock-helm-chart/
 helm repo update
 helm search repo tock
-helm install [RELEASE_NAME] tock/tock --version 0.6.2
+helm install [RELEASE_NAME] tock/tock --version 0.6.3
 ```
 
 You will find more information on chart parameters at the helm chart [README](charts/tock/README.md).

--- a/charts/tock/Chart.yaml
+++ b/charts/tock/Chart.yaml
@@ -5,7 +5,7 @@ name: tock
 icon: https://doc.tock.ai/tock/assets/images/logo-white.svg
 home: https://doc.tock.ai
 type: application
-version: 0.6.2
+version: 0.6.3
 sources: 
 - https://github.com/theopenconversationkit/tock-helm-chart
 - https://github.com/theopenconversationkit

--- a/charts/tock/README.md
+++ b/charts/tock/README.md
@@ -2,7 +2,7 @@
 
 A helm chart for Tock. Tock is an open conversational AI platform. It's a complete solution to build conversational agents aka bots.Tock can integrate and experiment with both classic and Generative AI (LLM, RAG) models
 
-![Version: 0.6.2](https://img.shields.io/badge/Version-0.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 25.10.7](https://img.shields.io/badge/AppVersion-25.10.7-informational?style=flat-square)
+![Version: 0.6.3](https://img.shields.io/badge/Version-0.6.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 25.10.7](https://img.shields.io/badge/AppVersion-25.10.7-informational?style=flat-square)
 
 ## Usage
 
@@ -14,7 +14,7 @@ The chart is distributed as an OCI Artifact as well as via a traditional Helm Re
 ## Install Chart
 
 ```console
-$ helm install [RELEASE_NAME] oci://ghcr.io/theopenconversationkit/charts/tock --version 0.6.2
+$ helm install [RELEASE_NAME] oci://ghcr.io/theopenconversationkit/charts/tock --version 0.6.3
 ```
 
 or
@@ -23,7 +23,7 @@ or
 helm repo add tock https://theopenconversationkit.github.io/tock-helm-chart/
 helm repo update
 helm search repo tock
-helm install [RELEASE_NAME] tock/tock --version 0.6.2
+helm install [RELEASE_NAME] tock/tock --version 0.6.3
 ```
 
 ## Introduction

--- a/charts/tock/templates/bot_api.configmap.yaml
+++ b/charts/tock/templates/bot_api.configmap.yaml
@@ -68,5 +68,5 @@ data:
     tock_bot_mongo_db: '{{ tpl .Values.global.tockMongodbBot . }}'
 {{- end }}
 {{- if .Values.botApi.truststore }}
-    JAVA_TOOL_OPTIONS: '-Djavax.net.ssl.trustStore=/truststore/truststore.jks -Djavax.net.ssl.trustStorePassword=changeit'
- {{- end }}   
+    JAVA_TOOL_OPTIONS: '-Djavax.net.ssl.trustStore=/truststore/cacerts -Djavax.net.ssl.trustStorePassword=changeit'
+ {{- end }} 

--- a/charts/tock/templates/bot_api.deployment.yaml
+++ b/charts/tock/templates/bot_api.deployment.yaml
@@ -81,11 +81,21 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             - |
-              keytool -importcert -noprompt \
-                -file /etc/ssl/certs/{{ .Values.botApi.truststore.certSecret }}.crt \
-                -alias corp-root \
-                -keystore /truststore/truststore.jks \
-                -storepass changeit;
+              set -e
+              cp "$JAVA_HOME/lib/security/cacerts" /truststore/cacerts
+              csplit -f /tmp/corp- -b '%02d.pem' /etc/ssl/certs/{{ .Values.botApi.truststore.certSecret }}.crt '/-----BEGIN CERTIFICATE-----/' '{*}' >/dev/null || true
+              i=0
+              for f in /tmp/corp-*.pem; do
+                [ -s "$f" ] || continue
+                keytool -importcert -noprompt \
+                 -file "$f" \
+                 -alias "corp-$i" \
+                 -keystore /truststore/cacerts \
+                 -storepass changeit
+                i=$((i+1))
+              done
+              keytool -list -keystore /truststore/cacerts -storepass changeit | grep -i corp || true
+              chmod 0444 /truststore/cacerts
           volumeMounts:
             - name: cert-volume
               mountPath: /etc/ssl/certs/{{ .Values.botApi.truststore.certSecret }}.crt

--- a/charts/tock/templates/genai_orchestrator.configmap.yaml
+++ b/charts/tock/templates/genai_orchestrator.configmap.yaml
@@ -36,4 +36,6 @@ data:
 {{- if .Values.genAiOrchestrator.environment.OPENAI_API_BASE }}
     OPENAI_API_BASE: '{{ default "https://api.openai.com/v1" .Values.genAiOrchestrator.environment.OPENAI_API_BASE . }}'
 {{- end }}
-  
+{{- if .Values.genAiOrchestrator.truststore }}
+    JAVA_TOOL_OPTIONS: '-Djavax.net.ssl.trustStore=/truststore/cacerts -Djavax.net.ssl.trustStorePassword=changeit'
+{{- end }}

--- a/charts/tock/templates/genai_orchestrator.deployment.yaml
+++ b/charts/tock/templates/genai_orchestrator.deployment.yaml
@@ -60,11 +60,21 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
             - |
-              keytool -importcert -noprompt \
-                -file /etc/ssl/certs/{{ .Values.genAiOrchestrator.truststore.certSecret }}.crt \
-                -alias corp-root \
-                -keystore /truststore/truststore.jks \
-                -storepass changeit;
+              set -e
+              cp "$JAVA_HOME/lib/security/cacerts" /truststore/cacerts
+              csplit -f /tmp/corp- -b '%02d.pem' /etc/ssl/certs/{{ .Values.genAiOrchestrator.truststore.certSecret }}.crt '/-----BEGIN CERTIFICATE-----/' '{*}' >/dev/null || true
+              i=0
+              for f in /tmp/corp-*.pem; do
+                [ -s "$f" ] || continue
+                keytool -importcert -noprompt \
+                 -file "$f" \
+                 -alias "corp-$i" \
+                 -keystore /truststore/cacerts \
+                 -storepass changeit
+                i=$((i+1))
+              done
+              keytool -list -keystore /truststore/cacerts -storepass changeit | grep -i corp || true
+              chmod 0444 /truststore/cacerts
         volumeMounts:
             - name: cert-volume
               mountPath: /etc/ssl/certs/{{ .Values.genAiOrchestrator.truststore.certSecret }}.crt


### PR DESCRIPTION
- Update chart version from 0.6.2 to 0.6.3 across all documentation
- Fix truststore implementation to use default Java cacerts instead of creating new keystore
- Add support for certificate bundles by splitting multi-cert files
- Apply truststore configuration to genai orchestrator component
- Improve error handling in certificate import scripts